### PR TITLE
Add motion tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   [Minor] Add tokens for light and dark scrims. These are values for transparent light and dark curtains that cover content.
+-   [Minor] Add tokens for animation durations for all platforms and easings for SCSS/JS only.
 
 ## 10.0.0 - 2019-11-05
 

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -574,6 +574,8 @@ public enum Duration {
     public static let duration4: 0.25
     public static let duration5: 0.3
     public static let duration6: 0.35
+}
+
 /// Values for transparent light and dark curtains that cover content.
 public enum Scrim {
     public static let light80: UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -45,6 +45,12 @@ exports[`outputted Android matches snapshot 1`] = `
     <color name=\\"tp_gray_300\\">#e9eced</color>
     <color name=\\"tp_gray\\">#d3d4d5</color>
     <color name=\\"tp_white\\">#ffffff</color>
+    <item name=\\"tp_duration_1\\">75</item>
+    <item name=\\"tp_duration_2\\">150</item>
+    <item name=\\"tp_duration_3\\">200</item>
+    <item name=\\"tp_duration_4\\">250</item>
+    <item name=\\"tp_duration_5\\">300</item>
+    <item name=\\"tp_duration_6\\">350</item>
     <dimen name=\\"tp_space_1\\">4dp</dimen>
     <dimen name=\\"tp_space_2\\">8dp</dimen>
     <dimen name=\\"tp_space_3\\">16dp</dimen>
@@ -114,6 +120,15 @@ exports.tpColorGray200 = \\"#fafafa\\";
 exports.tpColorGray300 = \\"#e9eced\\";
 exports.tpColorGray = \\"#d3d4d5\\";
 exports.tpColorWhite = \\"#ffffff\\";
+exports.tpDuration1 = \\"75ms\\";
+exports.tpDuration2 = \\"150ms\\";
+exports.tpDuration3 = \\"200ms\\";
+exports.tpDuration4 = \\"250ms\\";
+exports.tpDuration5 = \\"300ms\\";
+exports.tpDuration6 = \\"350ms\\";
+exports.tpEaseIn = \\"cubic-bezier(0.50, 0, 1, 1)\\";
+exports.tpEaseOut = \\"cubic-bezier(0, 0, 0.40, 1)\\";
+exports.tpEaseInOut = \\"cubic-bezier(0.45, 0, 0.40, 1)\\";
 exports.tpFontFamilyBase = \\"Mark, Avenir, Helvetica, Arial, sans-serif\\";
 exports.tpFontFamilyMonospace = \\"'Source Code Pro', monospace\\";
 exports.tpFontWeightNormal = \\"400\\";
@@ -240,6 +255,15 @@ export var tpColorGray200 = \\"#fafafa\\";
 export var tpColorGray300 = \\"#e9eced\\";
 export var tpColorGray = \\"#d3d4d5\\";
 export var tpColorWhite = \\"#ffffff\\";
+export var tpDuration1 = \\"75ms\\";
+export var tpDuration2 = \\"150ms\\";
+export var tpDuration3 = \\"200ms\\";
+export var tpDuration4 = \\"250ms\\";
+export var tpDuration5 = \\"300ms\\";
+export var tpDuration6 = \\"350ms\\";
+export var tpEaseIn = \\"cubic-bezier(0.50, 0, 1, 1)\\";
+export var tpEaseOut = \\"cubic-bezier(0, 0, 0.40, 1)\\";
+export var tpEaseInOut = \\"cubic-bezier(0.45, 0, 0.40, 1)\\";
 export var tpFontFamilyBase = \\"Mark, Avenir, Helvetica, Arial, sans-serif\\";
 export var tpFontFamilyMonospace = \\"'Source Code Pro', monospace\\";
 export var tpFontWeightNormal = \\"400\\";
@@ -366,6 +390,15 @@ $tp-color__gray-200: #fafafa;
 $tp-color__gray-300: #e9eced;
 $tp-color__gray: #d3d4d5;
 $tp-color__white: #ffffff;
+tp-duration__1: 75ms;
+tp-duration__2: 150ms;
+tp-duration__3: 200ms;
+tp-duration__4: 250ms;
+tp-duration__5: 300ms;
+tp-duration__6: 350ms;
+tp-ease__in: cubic-bezier(0.50, 0, 1, 1);
+tp-ease__out: cubic-bezier(0, 0, 0.40, 1);
+tp-ease__in-out: cubic-bezier(0.45, 0, 0.40, 1);
 $tp-font-family__base: Mark, Avenir, Helvetica, Arial, sans-serif;
 $tp-font-family__monospace: 'Source Code Pro', monospace;
 $tp-font-weight__normal: 400;
@@ -524,6 +557,15 @@ public enum Color {
     public static let gray: UIColor = UIColor(red: 0.827451, green: 0.83137256, blue: 0.8352941, alpha: 1.0)
     /// White – #ffffff
     public static let white: UIColor = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+}
+
+public enum Duration {
+    public static let duration1: 0.075
+    public static let duration2: 0.15
+    public static let duration3: 0.2
+    public static let duration4: 0.25
+    public static let duration5: 0.3
+    public static let duration6: 0.35
 }
 
 public enum Space {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1264,6 +1264,128 @@ module.exports = [
         ],
     },
     {
+        name: 'Duration',
+        tokens: [
+            {
+                id: '1',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-duration__1',
+                        value: '150ms',
+                    },
+                    javascript: {
+                        name: 'tpDuration1',
+                        value: '150ms',
+                    },
+                },
+            },
+            {
+                id: '2',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-duration__2',
+                        value: '200ms',
+                    },
+                    javascript: {
+                        name: 'tpDuration2',
+                        value: '200ms',
+                    },
+                },
+            },
+            {
+                id: '3',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-duration__3',
+                        value: '250ms',
+                    },
+                    javascript: {
+                        name: 'tpDuration3',
+                        value: '250ms',
+                    },
+                },
+            },
+            {
+                id: '4',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-duration__4',
+                        value: '300ms',
+                    },
+                    javascript: {
+                        name: 'tpDuration4',
+                        value: '300ms',
+                    },
+                },
+            },
+            {
+                id: '5',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-duration__5',
+                        value: '350ms',
+                    },
+                    javascript: {
+                        name: 'tpDuration5',
+                        value: '350ms',
+                    },
+                },
+            },
+        ],
+    },
+    {
+        name: 'Easing',
+        tokens: [
+            {
+                id: 'ease-in',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-ease__in',
+                        value: 'cubic-bezier(0.50, 0, 1, 1)',
+                    },
+                    javascript: {
+                        name: 'tpEaseIn',
+                        value: 'cubic-bezier(0.50, 0, 1, 1)',
+                    },
+                },
+            },
+            {
+                id: 'ease-out',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-ease__out',
+                        value: 'cubic-bezier(0, 0, 0.40, 1)',
+                    },
+                    javascript: {
+                        name: 'tpEaseOut',
+                        value: 'cubic-bezier(0, 0, 0.40, 1)',
+                    },
+                },
+            },
+            {
+                id: 'ease-in-out',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-ease__in-out',
+                        value: 'cubic-bezier(0.45, 0, 0.40, 1)',
+                    },
+                    javascript: {
+                        name: 'tpEaseInOut',
+                        value: 'cubic-bezier(0.45, 0, 0.40, 1)',
+                    },
+                },
+            },
+        ],
+    },
+    {
         name: 'Font Family',
         tokens: [
             {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1272,11 +1272,19 @@ module.exports = [
                 platforms: {
                     scss: {
                         name: 'tp-duration__1',
-                        value: '150ms',
+                        value: '75ms',
                     },
                     javascript: {
                         name: 'tpDuration1',
-                        value: '150ms',
+                        value: '75ms',
+                    },
+                    ios: {
+                        name: 'duration1',
+                        value: '0.075',
+                    },
+                    android: {
+                        name: 'tp_duration_1',
+                        value: '75',
                     },
                 },
             },
@@ -1286,11 +1294,19 @@ module.exports = [
                 platforms: {
                     scss: {
                         name: 'tp-duration__2',
-                        value: '200ms',
+                        value: '150ms',
                     },
                     javascript: {
                         name: 'tpDuration2',
-                        value: '200ms',
+                        value: '150ms',
+                    },
+                    ios: {
+                        name: 'duration2',
+                        value: '0.15',
+                    },
+                    android: {
+                        name: 'tp_duration_2',
+                        value: '150',
                     },
                 },
             },
@@ -1300,11 +1316,19 @@ module.exports = [
                 platforms: {
                     scss: {
                         name: 'tp-duration__3',
-                        value: '250ms',
+                        value: '200ms',
                     },
                     javascript: {
                         name: 'tpDuration3',
-                        value: '250ms',
+                        value: '200ms',
+                    },
+                    ios: {
+                        name: 'duration3',
+                        value: '0.2',
+                    },
+                    android: {
+                        name: 'tp_duration_3',
+                        value: '200',
                     },
                 },
             },
@@ -1314,11 +1338,19 @@ module.exports = [
                 platforms: {
                     scss: {
                         name: 'tp-duration__4',
-                        value: '300ms',
+                        value: '250ms',
                     },
                     javascript: {
                         name: 'tpDuration4',
-                        value: '300ms',
+                        value: '250ms',
+                    },
+                    ios: {
+                        name: 'duration4',
+                        value: '0.25',
+                    },
+                    android: {
+                        name: 'tp_duration_4',
+                        value: '250',
                     },
                 },
             },
@@ -1328,11 +1360,41 @@ module.exports = [
                 platforms: {
                     scss: {
                         name: 'tp-duration__5',
-                        value: '350ms',
+                        value: '300ms',
                     },
                     javascript: {
                         name: 'tpDuration5',
+                        value: '300ms',
+                    },
+                    ios: {
+                        name: 'duration5',
+                        value: '0.3',
+                    },
+                    android: {
+                        name: 'tp_duration_5',
+                        value: '300',
+                    },
+                },
+            },
+            {
+                id: '6',
+                type: 'string',
+                platforms: {
+                    scss: {
+                        name: 'tp-duration__6',
                         value: '350ms',
+                    },
+                    javascript: {
+                        name: 'tpDuration6',
+                        value: '350ms',
+                    },
+                    ios: {
+                        name: 'duration6',
+                        value: '0.35',
+                    },
+                    android: {
+                        name: 'tp_duration_6',
+                        value: '350',
                     },
                 },
             },


### PR DESCRIPTION
Adds tokens for use in animations.

- All platforms will get duration tokens
- Only SCSS/JS will get easing tokens, native teams will use built-in (confirmed with native teams)