### PR TITLE
Add font, font weight, and border radius for iOS

### DIFF
--- a/functions/graphql/graphql.js
+++ b/functions/graphql/graphql.js
@@ -31,6 +31,7 @@ const typeDefs = gql`
         color
         size
         time
+        fontWeight
     }
 
     type Token {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -479,6 +479,10 @@ $tp-z-index__modal: 200;
 exports[`outputted iOS matches snapshot 1`] = `
 "import UIKit.UIColor
 
+public enum BorderRadius {
+    public static let base: CGFloat = 4
+}
+
 /// These are the colors we use at Thumbtack.
 public enum Color {
     /// Blue 100 – #eaf6fa
@@ -574,6 +578,33 @@ public enum Duration {
     public static let duration4: TimeInterval = 0.25
     public static let duration5: TimeInterval = 0.3
     public static let duration6: TimeInterval = 0.35
+}
+
+public enum FontWeight {
+    case normal
+    case bold
+}
+
+public enum FontAttributes {
+    public static let title1Size: CGFloat = 28
+    public static let title1Weight: FontWeight = .bold
+    public static let title2Size: CGFloat = 28
+    public static let title2Weight: FontWeight = .bold
+    public static let title3Size: CGFloat = 22
+    public static let title3Weight: FontWeight = .bold
+    public static let title4Size: CGFloat = 20
+    public static let title4Weight: FontWeight = .bold
+    public static let title5Size: CGFloat = 18
+    public static let title5Weight: FontWeight = .bold
+    public static let title6Size: CGFloat = 16
+    public static let title6Weight: FontWeight = .bold
+    public static let title7Size: CGFloat = 14
+    public static let title7Weight: FontWeight = .bold
+    public static let title8Size: CGFloat = 12
+    public static let title8Weight: FontWeight = .bold
+    public static let body1Size: CGFloat = 16
+    public static let body2Size: CGFloat = 14
+    public static let body3Size: CGFloat = 12
 }
 
 /// Values for transparent light and dark curtains that cover content.

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -479,10 +479,6 @@ $tp-z-index__modal: 200;
 exports[`outputted iOS matches snapshot 1`] = `
 "import UIKit.UIColor
 
-public enum BorderRadius {
-    public static let base: CGFloat = 4
-}
-
 /// These are the colors we use at Thumbtack.
 public enum Color {
     /// Blue 100 – #eaf6fa

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -585,7 +585,7 @@ public enum FontWeight {
     case bold
 }
 
-public enum FontAttributes {
+public enum Font {
     public static let title1Size: CGFloat = 28
     public static let title1Weight: FontWeight = .bold
     public static let title2Size: CGFloat = 28

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -598,9 +598,9 @@ public enum Font {
     public static let title7Weight: FontWeight = .bold
     public static let title8Size: CGFloat = 12
     public static let title8Weight: FontWeight = .bold
-    public static let body1Size: CGFloat = 16
-    public static let body2Size: CGFloat = 14
-    public static let body3Size: CGFloat = 12
+    public static let text1Size: CGFloat = 16
+    public static let text2Size: CGFloat = 14
+    public static let text3Size: CGFloat = 12
 }
 
 /// Values for transparent light and dark curtains that cover content.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -51,6 +51,9 @@ module.exports = {
 
         return 'item';
     },
+
     isString: (arg1, options) =>
         typeof arg1 === 'string' ? options.fn(this) : options.inverse(this),
+
+    ifEquals: (arg1, arg2, options) => (arg1 === arg2 ? options.fn(this) : options.inverse(this)),
 };

--- a/src/templates/ios.handlebars
+++ b/src/templates/ios.handlebars
@@ -4,7 +4,7 @@ import UIKit.UIColor
 {{#if description}}
 /// {{description}}
 {{/if}}
-public enum {{#if this.memberName.ios}}{{removeSpaces this.memberName.ios}}{{else}}{{removeSpaces this.name}}{{/if}} {
+public enum {{#if this.memberName.ios}}{{this.memberName.ios}}{{else}}{{removeSpaces this.name}}{{/if}} {
     {{#each tokens as |token|}}
     {{#if token.platforms.ios}}
     {{#if token.platforms.ios.description}}

--- a/src/templates/ios.handlebars
+++ b/src/templates/ios.handlebars
@@ -13,8 +13,8 @@ public enum {{removeSpaces this.name}} {
     {{#if token.deprecated}}
     @available(*, deprecated)
     {{/if}}
-    {{#ifEquals token.platforms.ios.type "enumCase"}}
-    case {{token.platforms.ios.name}}{{#if token.platforms.ios.value}} = {{{token.platforms.ios.value}}}{{/if}}
+    {{#ifEquals token.format "fontWeight"}}
+    case {{token.platforms.ios.name}}
     {{else}}
     public static let {{token.platforms.ios.name}}: {{{token.platforms.ios.value}}}
     {{/ifEquals}}

--- a/src/templates/ios.handlebars
+++ b/src/templates/ios.handlebars
@@ -4,7 +4,7 @@ import UIKit.UIColor
 {{#if description}}
 /// {{description}}
 {{/if}}
-public enum {{#if this.memberName.ios}}{{this.memberName.ios}}{{else}}{{removeSpaces this.name}}{{/if}} {
+public enum {{removeSpaces this.name}} {
     {{#each tokens as |token|}}
     {{#if token.platforms.ios}}
     {{#if token.platforms.ios.description}}

--- a/src/templates/ios.handlebars
+++ b/src/templates/ios.handlebars
@@ -4,7 +4,7 @@ import UIKit.UIColor
 {{#if description}}
 /// {{description}}
 {{/if}}
-public enum {{removeSpaces this.name}} {
+public enum {{#if this.memberName.ios}}{{removeSpaces this.memberName.ios}}{{else}}{{removeSpaces this.name}}{{/if}} {
     {{#each tokens as |token|}}
     {{#if token.platforms.ios}}
     {{#if token.platforms.ios.description}}
@@ -13,7 +13,11 @@ public enum {{removeSpaces this.name}} {
     {{#if token.deprecated}}
     @available(*, deprecated)
     {{/if}}
+    {{#ifEquals token.platforms.ios.type "enumCase"}}
+    case {{token.platforms.ios.name}}{{#if token.platforms.ios.value}} = {{{token.platforms.ios.value}}}{{/if}}
+    {{else}}
     public static let {{token.platforms.ios.name}}: {{{token.platforms.ios.value}}}
+    {{/ifEquals}}
     {{/if}}
     {{/each}}
 }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -2000,7 +2000,7 @@ module.exports = [
                         value: '16px',
                     },
                     ios: {
-                        name: 'body1Size',
+                        name: 'text1Size',
                         value: 'CGFloat = 16',
                     },
                 },
@@ -2032,7 +2032,7 @@ module.exports = [
                         value: '14px',
                     },
                     ios: {
-                        name: 'body2Size',
+                        name: 'text2Size',
                         value: 'CGFloat = 14',
                     },
                 },
@@ -2064,7 +2064,7 @@ module.exports = [
                         value: '12px',
                     },
                     ios: {
-                        name: 'body3Size',
+                        name: 'text3Size',
                         value: 'CGFloat = 12',
                     },
                 },

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1428,6 +1428,7 @@ module.exports = [
         tokens: [
             {
                 id: 'normal',
+                format: 'fontWeight',
                 platforms: {
                     scss: {
                         name: '$tp-font-weight__normal',
@@ -1439,12 +1440,12 @@ module.exports = [
                     },
                     ios: {
                         name: 'normal',
-                        type: 'enumCase',
                     },
                 },
             },
             {
                 id: 'bold',
+                format: 'fontWeight',
                 platforms: {
                     scss: {
                         name: '$tp-font-weight__bold',
@@ -1456,7 +1457,6 @@ module.exports = [
                     },
                     ios: {
                         name: 'bold',
-                        type: 'enumCase',
                     },
                 },
             },

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1464,9 +1464,6 @@ module.exports = [
     },
     {
         name: 'Font',
-        memberName: {
-            ios: 'FontAttributes',
-        },
         tokens: [
             {
                 group: 'Title 1',

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -13,6 +13,10 @@ module.exports = [
                         name: 'tpBorderRadiusBase',
                         value: '4px',
                     },
+                    ios: {
+                        name: 'base',
+                        value: 'CGFloat = 4',
+                    },
                 },
             },
             {
@@ -1433,6 +1437,10 @@ module.exports = [
                         name: 'tpFontWeightNormal',
                         value: '400',
                     },
+                    ios: {
+                        name: 'normal',
+                        type: 'enumCase',
+                    },
                 },
             },
             {
@@ -1446,12 +1454,19 @@ module.exports = [
                         name: 'tpFontWeightBold',
                         value: '700',
                     },
+                    ios: {
+                        name: 'bold',
+                        type: 'enumCase',
+                    },
                 },
             },
         ],
     },
     {
         name: 'Font',
+        memberName: {
+            ios: 'FontAttributes',
+        },
         tokens: [
             {
                 group: 'Title 1',
@@ -1464,6 +1479,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle1Size',
                         value: '28px',
+                    },
+                    ios: {
+                        name: 'title1Size',
+                        value: 'CGFloat = 28',
                     },
                 },
             },
@@ -1492,6 +1511,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle1Weight',
                         value: '700',
+                    },
+                    ios: {
+                        name: 'title1Weight',
+                        value: 'FontWeight = .bold',
                     },
                 },
             },
@@ -1549,6 +1572,10 @@ module.exports = [
                         name: 'tpFontTitle2Size',
                         value: '24px',
                     },
+                    ios: {
+                        name: 'title2Size',
+                        value: 'CGFloat = 28',
+                    },
                 },
             },
             {
@@ -1576,6 +1603,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle2Weight',
                         value: '700',
+                    },
+                    ios: {
+                        name: 'title2Weight',
+                        value: 'FontWeight = .bold',
                     },
                 },
             },
@@ -1633,6 +1664,10 @@ module.exports = [
                         name: 'tpFontTitle3Size',
                         value: '22px',
                     },
+                    ios: {
+                        name: 'title3Size',
+                        value: 'CGFloat = 22',
+                    },
                 },
             },
             {
@@ -1660,6 +1695,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle3Weight',
                         value: '700',
+                    },
+                    ios: {
+                        name: 'title3Weight',
+                        value: 'FontWeight = .bold',
                     },
                 },
             },
@@ -1717,6 +1756,10 @@ module.exports = [
                         name: 'tpFontTitle4Size',
                         value: '20px',
                     },
+                    ios: {
+                        name: 'title4Size',
+                        value: 'CGFloat = 20',
+                    },
                 },
             },
             {
@@ -1745,6 +1788,10 @@ module.exports = [
                         name: 'tpFontTitle4Weight',
                         value: '700',
                     },
+                    ios: {
+                        name: 'title4Weight',
+                        value: 'FontWeight = .bold',
+                    },
                 },
             },
             {
@@ -1758,6 +1805,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle5Size',
                         value: '18px',
+                    },
+                    ios: {
+                        name: 'title5Size',
+                        value: 'CGFloat = 18',
                     },
                 },
             },
@@ -1787,6 +1838,10 @@ module.exports = [
                         name: 'tpFontTitle5Weight',
                         value: '700',
                     },
+                    ios: {
+                        name: 'title5Weight',
+                        value: 'FontWeight = .bold',
+                    },
                 },
             },
             {
@@ -1800,6 +1855,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle6Size',
                         value: '16px',
+                    },
+                    ios: {
+                        name: 'title6Size',
+                        value: 'CGFloat = 16',
                     },
                 },
             },
@@ -1829,6 +1888,10 @@ module.exports = [
                         name: 'tpFontTitle6Weight',
                         value: '700',
                     },
+                    ios: {
+                        name: 'title6Weight',
+                        value: 'FontWeight = .bold',
+                    },
                 },
             },
             {
@@ -1842,6 +1905,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle7Size',
                         value: '14px',
+                    },
+                    ios: {
+                        name: 'title7Size',
+                        value: 'CGFloat = 14',
                     },
                 },
             },
@@ -1871,6 +1938,10 @@ module.exports = [
                         name: 'tpFontTitle7Weight',
                         value: '700',
                     },
+                    ios: {
+                        name: 'title7Weight',
+                        value: 'FontWeight = .bold',
+                    },
                 },
             },
             {
@@ -1884,6 +1955,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontTitle8Size',
                         value: '12px',
+                    },
+                    ios: {
+                        name: 'title8Size',
+                        value: 'CGFloat = 12',
                     },
                 },
             },
@@ -1913,6 +1988,10 @@ module.exports = [
                         name: 'tpFontTitle8Weight',
                         value: '700',
                     },
+                    ios: {
+                        name: 'title8Weight',
+                        value: 'FontWeight = .bold',
+                    },
                 },
             },
             {
@@ -1926,6 +2005,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontBody1Size',
                         value: '16px',
+                    },
+                    ios: {
+                        name: 'body1Size',
+                        value: 'CGFloat = 16',
                     },
                 },
             },
@@ -1955,6 +2038,10 @@ module.exports = [
                         name: 'tpFontBody2Size',
                         value: '14px',
                     },
+                    ios: {
+                        name: 'body2Size',
+                        value: 'CGFloat = 14',
+                    },
                 },
             },
             {
@@ -1982,6 +2069,10 @@ module.exports = [
                     javascript: {
                         name: 'tpFontBody3Size',
                         value: '12px',
+                    },
+                    ios: {
+                        name: 'body3Size',
+                        value: 'CGFloat = 12',
                     },
                 },
             },

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -13,10 +13,6 @@ module.exports = [
                         name: 'tpBorderRadiusBase',
                         value: '4px',
                     },
-                    ios: {
-                        name: 'base',
-                        value: 'CGFloat = 4',
-                    },
                 },
             },
             {


### PR DESCRIPTION
1) Add iOS exports for font, font weight, and border radius tokens
~2) Add support for a platform-specific `memberName` when simply using `{{removeSpaces this.name}}` could create a conflict (in this case, the iOS repo is defining `class Font` with constants for the actual `UIFont` instances, whereas what's being exported as part of this pod is simply the values for the font size & weight. Therefore it seemed more appropriate to name this pod's member `FontAttributes`.~ Realized this wasn't necessary after all
~3) Add support for a `token.platforms.ios.type` property to specify how each token should be defined. Previously, all tokens were defined as constants (`public static let ...`), but now there is also an `enumCase` option which will define them as `case ...` (useful for font weight, which is semantically an enum with no raw values).~