### PR TITLE
Rename duration tokens on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Major] Rename iOS duration tokens to `one`, `two`, `three` (and so on…) rather than `duration1`, `duration2`, etc…
+
 ## 11.0.0 - 2019-12-18
 
 ### Changed

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -568,12 +568,12 @@ public enum Color {
 }
 
 public enum Duration {
-    public static let duration1: TimeInterval = 0.075
-    public static let duration2: TimeInterval = 0.15
-    public static let duration3: TimeInterval = 0.2
-    public static let duration4: TimeInterval = 0.25
-    public static let duration5: TimeInterval = 0.3
-    public static let duration6: TimeInterval = 0.35
+    public static let one: TimeInterval = 0.075
+    public static let two: TimeInterval = 0.15
+    public static let three: TimeInterval = 0.2
+    public static let four: TimeInterval = 0.25
+    public static let five: TimeInterval = 0.3
+    public static let six: TimeInterval = 0.35
 }
 
 /// Values for transparent light and dark curtains that cover content.

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1223,7 +1223,7 @@ module.exports = [
                         value: 75,
                     },
                     ios: {
-                        name: 'duration1',
+                        name: 'one',
                         value: 'TimeInterval = 0.075',
                     },
                     android: {
@@ -1245,7 +1245,7 @@ module.exports = [
                         value: 150,
                     },
                     ios: {
-                        name: 'duration2',
+                        name: 'two',
                         value: 'TimeInterval = 0.15',
                     },
                     android: {
@@ -1267,7 +1267,7 @@ module.exports = [
                         value: 200,
                     },
                     ios: {
-                        name: 'duration3',
+                        name: 'three',
                         value: 'TimeInterval = 0.2',
                     },
                     android: {
@@ -1289,7 +1289,7 @@ module.exports = [
                         value: 250,
                     },
                     ios: {
-                        name: 'duration4',
+                        name: 'four',
                         value: 'TimeInterval = 0.25',
                     },
                     android: {
@@ -1311,7 +1311,7 @@ module.exports = [
                         value: 300,
                     },
                     ios: {
-                        name: 'duration5',
+                        name: 'five',
                         value: 'TimeInterval = 0.3',
                     },
                     android: {
@@ -1333,7 +1333,7 @@ module.exports = [
                         value: 350,
                     },
                     ios: {
-                        name: 'duration6',
+                        name: 'six',
                         value: 'TimeInterval = 0.35',
                     },
                     android: {


### PR DESCRIPTION
Update token names to match the naming convention used for Space.

(Since the constants are inside the `Duration` namespace, referring to `Duration.duration1` is kinda redundant which is why we'd decided upon `Space.one` instead for the Space tokens)