### PR TITLE
Fix the `bold`/`normal` token schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Fix the `bold`/`normal` token shema. This doesn't affect the distributed code.
+
 ## 12.0.0 - 2020-01-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
--   [Patch] Fix the `bold`/`normal` token shema. This doesn't affect the distributed code.
+-   [Patch] Fix the `bold`/`normal` token schema. This doesn't affect the distributed code.
 
 ## 12.0.0 - 2020-01-14
 

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1501,6 +1501,7 @@ module.exports = [
                     },
                     ios: {
                         name: 'normal',
+                        value: 'normal',
                     },
                 },
             },
@@ -1518,6 +1519,7 @@ module.exports = [
                     },
                     ios: {
                         name: 'bold',
+                        value: 'bold',
                     },
                 },
             },


### PR DESCRIPTION
The thumbprint.design` site expects every token to have a name and a value.