### PR TITLE
Attempt to fix the Android build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+-   [Patch] Attempt to fix the Android build.
+
 ## 12.2.0 - 2023-01-24
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'maven-publish'
-    id 'com.moowork.node' version '1.3.1'
+    id 'com.github.node-gradle.node' version '3.5.1'
 }
 
 apply plugin: 'com.android.library'

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -45,49 +45,49 @@ exports[`outputted Android matches snapshot 1`] = `
     <color name=\\"tp_gray_300\\">#e9eced</color>
     <color name=\\"tp_gray\\">#d3d4d5</color>
     <color name=\\"tp_white\\">#ffffff</color>
-    <item name=\\"tp_corner_radius_base\\">4dp</item>
-    <item name=\\"tp_corner_radius_big\\">6dp</item>
+    <dimen name=\\"tp_corner_radius_base\\">4dp</dimen>
+    <dimen name=\\"tp_corner_radius_big\\">6dp</dimen>
     <integer name=\\"tp_duration_1\\">75</integer>
     <integer name=\\"tp_duration_2\\">150</integer>
     <integer name=\\"tp_duration_3\\">200</integer>
     <integer name=\\"tp_duration_4\\">250</integer>
     <integer name=\\"tp_duration_5\\">300</integer>
     <integer name=\\"tp_duration_6\\">350</integer>
-    <item name=\\"tp_font_weight_normal\\">400</item>
-    <item name=\\"tp_font_weight_bold\\">700</item>
-    <item name=\\"tp_title_1_size\\">28sp</item>
-    <item name=\\"tp_title_1_line_height\\">32sp</item>
-    <item name=\\"tp_title_1_weight\\">700</item>
-    <item name=\\"tp_title_2_size\\">24sp</item>
-    <item name=\\"tp_title_2_line_height\\">28sp</item>
-    <item name=\\"tp_title_2_weight\\">700</item>
-    <item name=\\"tp_title_3_size\\">22sp</item>
-    <item name=\\"tp_title_3_line_height\\">28sp</item>
-    <item name=\\"tp_title_3_weight\\">700</item>
-    <item name=\\"tp_title_4_size\\">20sp</item>
-    <item name=\\"tp_title_4_line_height\\">28sp</item>
-    <item name=\\"tp_title_4_weight\\">700</item>
-    <item name=\\"tp_title_5_size\\">18sp</item>
-    <item name=\\"tp_title_5_line_height\\">24sp</item>
-    <item name=\\"tp_title_5_weight\\">700</item>
-    <item name=\\"tp_title_6_size\\">16sp</item>
-    <item name=\\"tp_title_6_line_height\\">24sp</item>
-    <item name=\\"tp_title_6_weight\\">700</item>
-    <item name=\\"tp_title_7_size\\">14sp</item>
-    <item name=\\"tp_title_7_line_height\\">20sp</item>
-    <item name=\\"tp_title_7_weight\\">700</item>
-    <item name=\\"tp_title_8_size\\">12sp</item>
-    <item name=\\"tp_title_8_line_height\\">18sp</item>
-    <item name=\\"tp_title_8_weight\\">700</item>
-    <item name=\\"tp_body_1_size\\">16sp</item>
-    <item name=\\"tp_body_1_line_height\\">24sp</item>
-    <item name=\\"tp_body_1_weight\\">400</item>
-    <item name=\\"tp_body_2_size\\">14sp</item>
-    <item name=\\"tp_body_2_line_height\\">20sp</item>
-    <item name=\\"tp_body_2_weight\\">400</item>
-    <item name=\\"tp_body_3_size\\">12sp</item>
-    <item name=\\"tp_body_3_line_height\\">18sp</item>
-    <item name=\\"tp_body_3_weight\\">400</item>
+    <integer name=\\"tp_font_weight_normal\\">400</integer>
+    <integer name=\\"tp_font_weight_bold\\">700</integer>
+    <dimen name=\\"tp_title_1_size\\">28sp</dimen>
+    <dimen name=\\"tp_title_1_line_height\\">32sp</dimen>
+    <integer name=\\"tp_title_1_weight\\">700</integer>
+    <dimen name=\\"tp_title_2_size\\">24sp</dimen>
+    <dimen name=\\"tp_title_2_line_height\\">28sp</dimen>
+    <integer name=\\"tp_title_2_weight\\">700</integer>
+    <dimen name=\\"tp_title_3_size\\">22sp</dimen>
+    <dimen name=\\"tp_title_3_line_height\\">28sp</dimen>
+    <integer name=\\"tp_title_3_weight\\">700</integer>
+    <dimen name=\\"tp_title_4_size\\">20sp</dimen>
+    <dimen name=\\"tp_title_4_line_height\\">28sp</dimen>
+    <integer name=\\"tp_title_4_weight\\">700</integer>
+    <dimen name=\\"tp_title_5_size\\">18sp</dimen>
+    <dimen name=\\"tp_title_5_line_height\\">24sp</dimen>
+    <integer name=\\"tp_title_5_weight\\">700</integer>
+    <dimen name=\\"tp_title_6_size\\">16sp</dimen>
+    <dimen name=\\"tp_title_6_line_height\\">24sp</dimen>
+    <integer name=\\"tp_title_6_weight\\">700</integer>
+    <dimen name=\\"tp_title_7_size\\">14sp</dimen>
+    <dimen name=\\"tp_title_7_line_height\\">20sp</dimen>
+    <integer name=\\"tp_title_7_weight\\">700</integer>
+    <dimen name=\\"tp_title_8_size\\">12sp</dimen>
+    <dimen name=\\"tp_title_8_line_height\\">18sp</dimen>
+    <integer name=\\"tp_title_8_weight\\">700</integer>
+    <dimen name=\\"tp_body_1_size\\">16sp</dimen>
+    <dimen name=\\"tp_body_1_line_height\\">24sp</dimen>
+    <integer name=\\"tp_body_1_weight\\">400</integer>
+    <dimen name=\\"tp_body_2_size\\">14sp</dimen>
+    <dimen name=\\"tp_body_2_line_height\\">20sp</dimen>
+    <integer name=\\"tp_body_2_weight\\">400</integer>
+    <dimen name=\\"tp_body_3_size\\">12sp</dimen>
+    <dimen name=\\"tp_body_3_line_height\\">18sp</dimen>
+    <integer name=\\"tp_body_3_weight\\">400</integer>
     <item name=\\"tp_letter_spacing_loose\\">1sp</item>
     <item name=\\"tp_letter_spacing_tight\\">-1sp</item>
     <item name=\\"tp_letter_spacing_extra_tight\\">-2sp</item>
@@ -654,37 +654,37 @@ public enum FontWeight {
 
 public enum Font {
     public static let title1Size: CGFloat = 28
-    public static let title1Weight: FontWeight = .bold
+    case title1Weight
     public static let title1UIFontTextStyle: UIFont.TextStyle = .headline
     public static let title2Size: CGFloat = 24
-    public static let title2Weight: FontWeight = .bold
+    case title2Weight
     public static let title2UIFontTextStyle: UIFont.TextStyle = .subheadline
     public static let title3Size: CGFloat = 22
-    public static let title3Weight: FontWeight = .bold
+    case title3Weight
     public static let title3UIFontTextStyle: UIFont.TextStyle = .title1
     public static let title4Size: CGFloat = 20
-    public static let title4Weight: FontWeight = .bold
+    case title4Weight
     public static let title4UIFontTextStyle: UIFont.TextStyle = .title2
     public static let title5Size: CGFloat = 18
-    public static let title5Weight: FontWeight = .bold
+    case title5Weight
     public static let title5UIFontTextStyle: UIFont.TextStyle = .title3
     public static let title6Size: CGFloat = 16
-    public static let title6Weight: FontWeight = .bold
+    case title6Weight
     public static let title6UIFontTextStyle: UIFont.TextStyle = .body
     public static let title7Size: CGFloat = 14
-    public static let title7Weight: FontWeight = .bold
+    case title7Weight
     public static let title7UIFontTextStyle: UIFont.TextStyle = .body
     public static let title8Size: CGFloat = 12
-    public static let title8Weight: FontWeight = .bold
+    case title8Weight
     public static let title8UIFontTextStyle: UIFont.TextStyle = .body
     public static let text1Size: CGFloat = 16
-    public static let text1Weight: FontWeight = .normal
+    case text1Weight
     public static let text1UIFontTextStyle: UIFont.TextStyle = .body
     public static let text2Size: CGFloat = 14
-    public static let text2Weight: FontWeight = .normal
+    case text2Weight
     public static let text2UIFontTextStyle: UIFont.TextStyle = .body
     public static let text3Size: CGFloat = 12
-    public static let text3Weight: FontWeight = .normal
+    case text3Weight
     public static let text3UIFontTextStyle: UIFont.TextStyle = .body
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -54,7 +54,7 @@ export default {
             return 'dimen';
         }
 
-        if (format === 'time') {
+        if (format === 'time' || format === 'fontWeight') {
             return 'integer';
         }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1197,6 +1197,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '4dp',
                     },
                 },
+                format: 'size',
             },
             {
                 id: 'big',
@@ -1214,6 +1215,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '6dp',
                     },
                 },
+                format: 'size',
             },
             {
                 id: 'full',
@@ -1227,6 +1229,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '50%',
                     },
                 },
+                format: 'size',
             },
             {
                 id: 'sides',
@@ -1240,6 +1243,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '9999px',
                     },
                 },
+                format: 'size',
             },
         ],
     },
@@ -1528,6 +1532,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '28sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 1',
@@ -1546,6 +1551,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '32sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 1',
@@ -1568,6 +1574,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 1',
@@ -1582,6 +1589,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '40px',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 1',
@@ -1596,6 +1604,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '44px',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 1',
@@ -1610,6 +1619,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 1',
@@ -1642,6 +1652,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '24sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 2',
@@ -1660,6 +1671,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '28sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 2',
@@ -1682,6 +1694,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 2',
@@ -1696,6 +1709,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '32px',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 2',
@@ -1710,6 +1724,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '40px',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 2',
@@ -1724,6 +1739,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 2',
@@ -1756,6 +1772,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '22sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 3',
@@ -1774,6 +1791,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '28sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 3',
@@ -1796,6 +1814,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 3',
@@ -1810,6 +1829,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '24px',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 3',
@@ -1824,6 +1844,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '32px',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 3',
@@ -1838,6 +1859,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 3',
@@ -1848,6 +1870,7 @@ const tokenGroups: TokenGroup[] = [
                         value: 'UIFont.TextStyle = .title1',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 4',
@@ -1870,6 +1893,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '20sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 4',
@@ -1888,6 +1912,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '28sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 4',
@@ -1910,6 +1935,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 4',
@@ -1942,6 +1968,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '18sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 5',
@@ -1960,6 +1987,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '24sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 5',
@@ -1982,6 +2010,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 5',
@@ -2014,6 +2043,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '16sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 6',
@@ -2032,6 +2062,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '24sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 6',
@@ -2054,6 +2085,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 6',
@@ -2086,6 +2118,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '14sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 7',
@@ -2104,6 +2137,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '20sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 7',
@@ -2126,6 +2160,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 7',
@@ -2158,6 +2193,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '12sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 8',
@@ -2176,6 +2212,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '18sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Title 8',
@@ -2198,6 +2235,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '700',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Title 8',
@@ -2230,6 +2268,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '16sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Body 1',
@@ -2248,6 +2287,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '24sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Body 1',
@@ -2262,6 +2302,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '400',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Body 1',
@@ -2294,6 +2335,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '14sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Body 2',
@@ -2312,6 +2354,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '20sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Body 2',
@@ -2326,6 +2369,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '400',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Body 2',
@@ -2358,6 +2402,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '12sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Body 3',
@@ -2376,6 +2421,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '18sp',
                     },
                 },
+                format: 'size',
             },
             {
                 group: 'Body 3',
@@ -2390,6 +2436,7 @@ const tokenGroups: TokenGroup[] = [
                         value: '400',
                     },
                 },
+                format: 'fontWeight',
             },
             {
                 group: 'Body 3',


### PR DESCRIPTION
A few things needed to happen:

1. Replace `com.moowork.node` with `com.github.node-gradle.node`. The former is no longer maintained and wasn't working well anymore since we've upgraded both Node and Yarn in the past year.
2. Change the `type` of some of the newly added Android tokens.

We should eventually rethink the `types` property to see if we can come up with types that make more sense. The existing ones were borrowed from Style Dictionary, Amazon's open-source design tokens project. Speaking of Style Dictionary, it may make sense to re-evaluate it as we work on semantic tokens in 2023.

I tested that this works by running `./gradlew build`. It fails on the `master` branch but passes on this commit.